### PR TITLE
Error on invalid commandline argument

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,6 +26,10 @@ while [[ $# -gt 0 ]]; do
             REPORT_FORMATS="$2"
             shift; shift
             ;;
+        *)
+            echo "ERROR: Found unknown commandline argument: ${1}"
+            exit 1
+            ;;
     esac
 done
 


### PR DESCRIPTION
Previously the parsing would continue in an endless loop. This behavior is now
removed by erroring on invalid input.