### PR TITLE
Remove explicit curations argument

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,8 +54,7 @@ mkdir -p "ort/results"
     --info \
     analyze \
     -i "." \
-    -o "ort" \
-    --package-curations-file "curations.yml"
+    -o "ort"
 LAST_OUTPUT_FILE="ort/analyzer-result.yml"
 
 cp "ort/analyzer-result.yml" "ort/results/"


### PR DESCRIPTION
The package-curations-file argument is not needed, as the curations file can be
loaded from the ORT_CONFIG_DIR/curations.yml Plus that will auto-detect,
preventing file errors.

Closes #17

Signed-off-by: Nico Rikken <nico.rikken@alliander.com>