### PR TITLE
feat: use Alliander built ORT container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM philipssoftware/ort:latest
+FROM ghcr.io/alliander-opensource/ort-container:latest
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
Use the latest daily build from alliander-opensource/ort-container via https://github.com/alliander-opensource/ort-container/pkgs/container/ort-container

Signed-off-by: Nico Rikken <nico.rikken@alliander.com>