### PR TITLE
feat: explicit exit codes in entrypoint script

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -62,7 +62,8 @@ mkdir -p "ort/results"
     --info \
     analyze \
     -i "." \
-    -o "ort"
+    -o "ort" \
+    || exit 1
 LAST_OUTPUT_FILE="ort/analyzer-result.yml"
 
 cp "ort/analyzer-result.yml" "ort/results/"
@@ -75,7 +76,8 @@ if "${RUN_DOWNLOAD}"; then
         --info \
         download \
         -i "ort/analyzer-result.yml" \
-        -o "ort/download"
+        -o "ort/download" \
+        || exit 1
 fi
 
 # Scan
@@ -85,7 +87,8 @@ if "${RUN_SCAN}"; then
         --info \
         scan \
         -i "ort/analyzer-result.yml" \
-        -o "ort/"
+        -o "ort/" \
+        || exit 1
     LAST_OUTPUT_FILE="ort/scan-result.yml"
 fi
 
@@ -97,9 +100,8 @@ if "${RUN_EVALUATE}"; then
         evaluate \
         -i "${LAST_OUTPUT_FILE}" \
         -o "ort" \
-        --package-curations-file "curations.yml"
-    # TODO: perhaps capture exit status and re-raise at the end
-
+        --package-curations-file "curations.yml" \
+        || exit 1
     LAST_OUTPUT_FILE="ort/evaluation-result.yml"
 
     cp "ort/evaluation-result.yml" "ort/results/"
@@ -113,7 +115,8 @@ if "${RUN_REPORT}"; then
         report \
         -f "${REPORT_FORMATS}" \
         -i "${LAST_OUTPUT_FILE}" \
-        -o ort/reports
+        -o ort/reports \
+        || exit 1
 
     cp -r "ort/reports" "ort/results/"
 fi

--- a/examples/npm-scan.yml
+++ b/examples/npm-scan.yml
@@ -47,6 +47,7 @@ jobs:
         ORT_CONFIG_DIR: '/github/workspace/ort-config/'
 
     - name: Store results
+      if: always()
       uses: actions/upload-artifact@v2
       with:
         name: license-scan-results


### PR DESCRIPTION
Explictly trigger an exit on each step based on the status. This ensures
the proper workflow exit status and prevents execution of further steps
that make no sense.

Signed-off-by: Nico Rikken <nico.rikken@alliander.com>
